### PR TITLE
Make video descriptions shorter because special characters

### DIFF
--- a/Functions/URLFollow.py
+++ b/Functions/URLFollow.py
@@ -82,8 +82,8 @@ class Instantiate(Function):
                 description = self.htmlParser.unescape(description)
                 description = re.sub('\n+', ' ', description)
                 description = re.sub('\s+', ' ', description)
-                if len(description) > 200:
-                    description = description[:197] + u'...'
+                if len(description) > 150:
+                    description = description[:147] + u'...'
                 
             return IRCResponse(ResponseType.Say, self.graySplitter.join([title, length, description]), message.ReplyTo)
         


### PR DESCRIPTION
Figured I'd help out since you're having lunch, I'm bored and PyMoronBot posted another YouTube description that was way too long :P
