### PR TITLE
Updating HangoutTracker.py

### DIFF
--- a/Functions/HangoutTracker.py
+++ b/Functions/HangoutTracker.py
@@ -26,10 +26,7 @@ class Instantiate(Function):
     def GetResponse(self, message):
         if message.Type != 'PRIVMSG':
             return
-            
-        if message.Type == 'JOIN':
-            if message.User.Name in ['Emily[iOS]']
-        
+
         match = re.search('^hango+?u?t$', message.Command, re.IGNORECASE)
         # If \hangouts is called or Emily[iOS] joins the Channel, Trigger Output.
         if (match or ((message.Type == 'JOIN') and (message.User.Name == 'Emily[iOS]'))):


### PR DESCRIPTION
Comments from Chat earlier today (SixFootTurkey) indicated that they did not like the user name being displayed on a \hangout call, because it was dinging them with the hangout being old.  Since we cannot figure out if the hangout is currently active, I decided to remove that part of the syntax all together.  I also went in and added additional syntax checks to the match line so that if Emily[iOS] joins the Channel, it automatically kicks off the message parsing and displays it to the room so I don't have to try and type \hangout while driving or waiting for a stoplight.
