### PR TITLE
Update HangoutTracker.py

### DIFF
--- a/Commands/HangoutTracker.py
+++ b/Commands/HangoutTracker.py
@@ -61,7 +61,10 @@ class HangoutTracker(CommandInterface):
             url = 'https://talkgadget.google.com/hangouts/_/{0}'.format(hangout.lastCode)
             byLine = 'first linked {0} ago'.format(StringUtils.deltaTimeToString(timeDiff))
 
-            response = 'Last hangout linked: {0} ({1})'.format(url, byLine)
+            if ((message.Type == 'JOIN') and (message.User.Name == 'Emily[iOS]')):
+                response = 'Welcome Back, Lady Emily.  Here\'s the !hangout for your streaming pleasure: {0} ({1})'.format(url, byLine)
+            else:
+                response = 'Last hangout linked: {0} ({1})'.format(url, byLine)
 
             return IRCResponse(ResponseType.Say, response, message.ReplyTo)
 


### PR DESCRIPTION
Adding specific trigger sentence before Automatic Output, so that the output doesn't seem to just be hanging out there and untriggered, confusing the users.
