### PR TITLE
Down: Strip HTTPS protocol from HTTPS URLs

### DIFF
--- a/Commands/Down.py
+++ b/Commands/Down.py
@@ -19,7 +19,9 @@ class Down(CommandInterface):
             return IRCResponse(ResponseType.Say, "You didn't give a URL! Usage: {0}".format(self.help), message.ReplyTo)
 
         url = message.Parameters
-        
+        if url.startsWith("https://"):
+            url = url[8:]
+
         webPage = WebUtils.fetchURL('http://www.downforeveryoneorjustme.com/{0}'.format(url))
         root = BeautifulSoup(webPage.body)
         downText = root.find('div').text.splitlines()[1].strip()


### PR DESCRIPTION
Apparently http://downforeveryoneorjustme.com/ screws up on these, so it's better to strip the HTTPS and treat them like normal HTTP URLs.
