### PR TITLE
Bring back the Stats command

### DIFF
--- a/Commands/Stats.py
+++ b/Commands/Stats.py
@@ -19,7 +19,5 @@ class Command(CommandInterface):
         @type message: IRCMessage
         """
         return IRCResponse(ResponseType.Say,
-                           'sss: http://www.moronic-works.co.uk/ | '
-                           #'pisg: http://silver.amazon.fooproject.net/pisg/desertbus.html | '
                            'pisg: http://pisg.michael-wheeler.org/desertbus.html',
                            message.ReplyTo)


### PR DESCRIPTION
Bring back the Stats command

mwheeler turned off the automatic nickname aliases so his stats page is actually accurate now.
