### PR TITLE
How about don't trigger on startswith(bot.nickname) in messages.

### DIFF
--- a/IRCMessage.py
+++ b/IRCMessage.py
@@ -95,7 +95,7 @@ class IRCMessage(object):
                 self.Parameters = u' '.join(self.MessageList[2:])
             else:
                 self.Parameters = u' '.join(self.MessageList[1:])
-        elif self.MessageList[0].startswith(bot.nickname) and len(self.MessageList) > 1:
+        elif self.MessageList[0] == bot.nickname and len(self.MessageList) > 1:
             self.Command = self.MessageList[1]
             self.Parameters = u' '.join(self.MessageList[2:])
 


### PR DESCRIPTION
PyMoronBot's help causes a trigger, which is a bit greedy.
(as does PyMoronBot's restart, which is a bit silly. We're just talking about it and he restarts <.<)
