### PR TITLE
Better URLFollow title detection by guessing the encoding

### DIFF
--- a/Commands/URLFollow.py
+++ b/Commands/URLFollow.py
@@ -516,6 +516,13 @@ class URLFollow(CommandInterface):
         return
 
     def GetTitle(self, webpage):
+        # BeautifulSoup doesn't do the right thing if you give it bytes.
+        # We're not 100% sure what the content-type of this page is meant to be,
+        # but UTF-8 is going to be right 90% of the time.
+        try:
+            webpage = webpage.decode('utf-8')
+        except UnicodeDecodeError:
+            pass
         soup = BeautifulSoup(webpage)
         title = soup.title
         if title:


### PR DESCRIPTION
BeautifulSoup seems to have issues with non-BMP UTF-8 when
you pass it bytes. Since mostly everything is UTF-8, this is a
good enough fix.

A real fix would be to correctly identify the encoding from the http headers, etc.

Fixes #140